### PR TITLE
[FIX] Downgrade react script to fix codesandbox err

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "querystringify": "2.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-scripts": "5.0.0",
+    "react-scripts": "4.0.3",
     "typescript": "4.5.4"
   },
   "scripts": {


### PR DESCRIPTION
Permet de fixer l'erreur CodeSandBox suivante: 
`Could not find/install babel plugin 'proposal-decorators': Cannot find plugin 'proposal-decorators' or 'babel-plugin-proposal-decorators'`